### PR TITLE
Fixs & features

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Converts JPG and PNG images to `.avif` files using `libavif` with the appended e
 2. Upload the `squidge` plugin to your `/wp-content/plugins/` directory.
 3. Activate the plugin through the "Plugins" menu in WordPress.
 4. Check the Settings tab under `Settings | Squidge Options` to ensure the libraries are installed, if they aren't,
-run the commands listed dependent on your operating system.
+   run the commands listed dependent on your operating system.
 5. Check the individual optimisation tabs and adjust settings accordingly.
 6. Done!
 
@@ -184,14 +184,15 @@ wp squidge run --jpeg=false --quality=80 --optimization=o3
 
 #### Arguments
 
-| Argument          | Default Value            | Accepted Values          | Description       |
-| ----------------- | ------------------------ | ------------------------ | ----------------- |
-| jpg               | `true`                   | `true`/`false`           | If JPG compression should run.
-| png               | `true`                   | `true`/`false`           | If PNG compression should run.
-| webp              | `true`                   | `true`/`false`           | If WebP conversion should run.
-| avif              | `true`                   | `true`/`false`           | If AVIF conversion should run.
-| quality           | `80`                     | `0` to `100`             | Compression quality of the images.
-| optimization      | `02`                     | `o1` to `o7`             | Optimisation of PNG images.
+| Argument     | Default Value | Accepted Values          | Description       |
+|--------------|---------------| ------------------------ | ----------------- |
+| jpg          | `true`        | `true`/`false`           | If JPG compression should run.
+| png          | `true`        | `true`/`false`           | If PNG compression should run.
+| webp         | `true`        | `true`/`false`           | If WebP conversion should run.
+| avif         | `true`        | `true`/`false`           | If AVIF conversion should run.
+| quality      | `80`          | `0` to `100`             | Compression quality of the images.
+| optimization | `02`          | `o1` to `o7`             | Optimisation of PNG images.
+| force        | `false`       | `true`/`false`           | Force reoptimization of already optimized images.
 
 ## Road Map
 

--- a/README.md
+++ b/README.md
@@ -184,15 +184,16 @@ wp squidge run --jpeg=false --quality=80 --optimization=o3
 
 #### Arguments
 
-| Argument     | Default Value | Accepted Values          | Description       |
-|--------------|---------------| ------------------------ | ----------------- |
-| jpg          | `true`        | `true`/`false`           | If JPG compression should run.
-| png          | `true`        | `true`/`false`           | If PNG compression should run.
-| webp         | `true`        | `true`/`false`           | If WebP conversion should run.
-| avif         | `true`        | `true`/`false`           | If AVIF conversion should run.
-| quality      | `80`          | `0` to `100`             | Compression quality of the images.
-| optimization | `02`          | `o1` to `o7`             | Optimisation of PNG images.
-| force        | `false`       | `true`/`false`           | Force reoptimization of already optimized images.
+| Argument        | Default Value | Accepted Values          | Description       |
+|-----------------|---------------| ------------------------ | ----------------- |
+| jpg             | `true`        | `true`/`false`           | If JPG compression should run.
+| png             | `true`        | `true`/`false`           | If PNG compression should run.
+| webp            | `true`        | `true`/`false`           | If WebP conversion should run.
+| avif            | `true`        | `true`/`false`           | If AVIF conversion should run.
+| quality         | `80`          | `0` to `100`             | Compression quality of the images.
+| optimization    | `02`          | `o1` to `o7`             | Optimisation of PNG images.
+| force           | `false`       | `true`/`false`           | Force reoptimization of already optimized images.
+| thumbnails-only | `false`       | `true`/`false`           | Optimize only thumbnails.
 
 ## Road Map
 

--- a/cli/Commands.php
+++ b/cli/Commands.php
@@ -65,10 +65,10 @@ class Squidge_CLI extends WP_CLI_Command
 	 * converted to .webp and .avif file formats.
 	 *
 	 * Args:
-	 *    - jpg=false       To disable JPG compression.
-	 *    - png=false     To disable PNG compression.
-	 *    - webp=false     To disable WebP conversion.
-	 *    - avif=false       To disable AVIF conversion.
+	 *    - jpg=true       To enable JPG compression.
+	 *    - png=true     To enable PNG compression.
+	 *    - webp=true     To enable WebP conversion.
+	 *    - avif=true       To enable AVIF conversion.
 	 *    - quality=80     The quality of compression
 	 *    - optimization=02  Optimization of PNG images
 	 *    - force=false  Force reoptimization of already optimized images

--- a/cli/Commands.php
+++ b/cli/Commands.php
@@ -72,6 +72,7 @@ class Squidge_CLI extends WP_CLI_Command
 	 *    - quality=80     The quality of compression
 	 *    - optimization=02  Optimization of PNG images
 	 *    - force=false  Force reoptimization of already optimized images
+	 *    - thumbnails-only=false  Only optimize thumbnails
 	 *
 	 * @param $args
 	 * @param $assoc_args
@@ -92,6 +93,7 @@ class Squidge_CLI extends WP_CLI_Command
 				'webp' => true,
 				'avif' => true,
 				'force' => false,
+				'thumbnails-only' => false,
 			]
 		);
 
@@ -100,6 +102,7 @@ class Squidge_CLI extends WP_CLI_Command
 		$assoc_args['webp'] = filter_var($assoc_args['webp'], FILTER_VALIDATE_BOOLEAN);
 		$assoc_args['avif'] = filter_var($assoc_args['avif'], FILTER_VALIDATE_BOOLEAN);
 		$assoc_args['force'] = filter_var($assoc_args['force'], FILTER_VALIDATE_BOOLEAN);
+		$assoc_args['thumbnailsOnly'] = filter_var($assoc_args['thumbnails-only'], FILTER_VALIDATE_BOOLEAN);
 
 		$page = 0;
 		$counter = 0;
@@ -121,6 +124,7 @@ class Squidge_CLI extends WP_CLI_Command
 					'quality' => $assoc_args['quality'],
 					'optimization' => $assoc_args['optimization'],
 					'force' => $assoc_args['force'],
+					'thumbnailsOnly' => $assoc_args['thumbnailsOnly'],
 				];
 
 				WP_CLI::log(WP_CLI::colorize("%BProcessing image: %n") . $image->post_title);

--- a/cli/Commands.php
+++ b/cli/Commands.php
@@ -71,6 +71,7 @@ class Squidge_CLI extends WP_CLI_Command
 	 *    - avif=false       To disable AVIF conversion.
 	 *    - quality=80     The quality of compression
 	 *    - optimization=02  Optimization of PNG images
+	 *    - force=false  Force reoptimization of already optimized images
 	 *
 	 * @param $args
 	 * @param $assoc_args
@@ -90,6 +91,7 @@ class Squidge_CLI extends WP_CLI_Command
 				'png' => true,
 				'webp' => true,
 				'avif' => true,
+				'force' => false,
 			]
 		);
 
@@ -97,6 +99,7 @@ class Squidge_CLI extends WP_CLI_Command
 		$assoc_args['png'] = filter_var($assoc_args['png'], FILTER_VALIDATE_BOOLEAN);
 		$assoc_args['webp'] = filter_var($assoc_args['webp'], FILTER_VALIDATE_BOOLEAN);
 		$assoc_args['avif'] = filter_var($assoc_args['avif'], FILTER_VALIDATE_BOOLEAN);
+		$assoc_args['force'] = filter_var($assoc_args['force'], FILTER_VALIDATE_BOOLEAN);
 
 		$page = 0;
 		$counter = 0;
@@ -116,7 +119,8 @@ class Squidge_CLI extends WP_CLI_Command
 				$id = $image->ID;
 				$image_args = [
 					'quality' => $assoc_args['quality'],
-					'optimization' => $assoc_args['optimization']
+					'optimization' => $assoc_args['optimization'],
+					'force' => $assoc_args['force'],
 				];
 
 				WP_CLI::log(WP_CLI::colorize("%BProcessing image: %n") . $image->post_title);

--- a/core/Admin/Upload.php
+++ b/core/Admin/Upload.php
@@ -66,7 +66,8 @@ class Upload
 		try {
 			$args = [
 				'quality' => carbon_get_theme_option('squidge_jpg_quality'),
-				'force' => false
+				'force' => false,
+				'thumbnailsOnly' => false
 			];
 			JPG::process($attachment, $args);
 		} catch (Exception $e) {
@@ -93,7 +94,8 @@ class Upload
 		try {
 			$args = [
 				'optimization' => carbon_get_theme_option('squidge_webp_quality'),
-				'force' => false
+				'force' => false,
+				'thumbnailsOnly' => false
 			];
 			PNG::process($attachment, $args);
 		} catch (Exception $e) {
@@ -121,7 +123,8 @@ class Upload
 		try {
 			$args = [
 				'quality' => carbon_get_theme_option('squidge_webp_quality'),
-				'force' => false
+				'force' => false,
+				'thumbnailsOnly' => false
 			];
 			WebP::process($attachment, $args);
 		} catch (Exception $e) {
@@ -148,7 +151,8 @@ class Upload
 
 		try {
 			$args = [
-				'force' => false
+				'force' => false,
+				'thumbnailsOnly' => false
 			];
 			AVIF::process($attachment, $args);
 		} catch (Exception $e) {

--- a/core/Admin/Upload.php
+++ b/core/Admin/Upload.php
@@ -66,6 +66,7 @@ class Upload
 		try {
 			$args = [
 				'quality' => carbon_get_theme_option('squidge_jpg_quality'),
+				'force' => false
 			];
 			JPG::process($attachment, $args);
 		} catch (Exception $e) {
@@ -92,6 +93,7 @@ class Upload
 		try {
 			$args = [
 				'optimization' => carbon_get_theme_option('squidge_webp_quality'),
+				'force' => false
 			];
 			PNG::process($attachment, $args);
 		} catch (Exception $e) {
@@ -119,6 +121,7 @@ class Upload
 		try {
 			$args = [
 				'quality' => carbon_get_theme_option('squidge_webp_quality'),
+				'force' => false
 			];
 			WebP::process($attachment, $args);
 		} catch (Exception $e) {
@@ -144,7 +147,10 @@ class Upload
 		}
 
 		try {
-			AVIF::process($attachment, []);
+			$args = [
+				'force' => false
+			];
+			AVIF::process($attachment, $args);
 		} catch (Exception $e) {
 			Logger::error($e->getMessage());
 		}

--- a/core/Package/Service.php
+++ b/core/Package/Service.php
@@ -72,7 +72,7 @@ class Service
 		}
 
 		// Convert main image.
-		static::convert($mainFile, self::get_mime_type($mainFile), $args);
+		if (!$args['thumbnailsOnly']) static::convert($mainFile, self::get_mime_type($mainFile), $args);
 
 		// Loop over the sizes and convert them.
 		foreach ($attachment['sizes'] as $size) {

--- a/core/Package/Service.php
+++ b/core/Package/Service.php
@@ -111,6 +111,9 @@ class Service
 		$sizes = get_intermediate_image_sizes();
 		foreach ($sizes as $size) {
 			$src = wp_get_attachment_image_src($id, $size);
+			if (!$src) {
+				continue;
+			}
 			$path = self::get_file_path($src[0] . static::extension());
 			if (!$path) {
 				continue;

--- a/core/Package/Service.php
+++ b/core/Package/Service.php
@@ -79,7 +79,8 @@ class Service
 			if (!isset($size['file'])) {
 				continue;
 			}
-			$path = self::get_file_path($size['file']);
+			$basepath = str_replace(basename($attachment['file']), "", $attachment['file']);
+			$path = self::get_file_path($basepath . $size['file']);
 			if (!$path) {
 				continue;
 			}
@@ -110,11 +111,11 @@ class Service
 		// Delete the image sizes.
 		$sizes = get_intermediate_image_sizes();
 		foreach ($sizes as $size) {
-			$src = wp_get_attachment_image_src($id, $size);
-			if (!$src) {
+			$fileInfos = image_get_intermediate_size($id, $size);
+			if (empty($fileInfos)) {
 				continue;
 			}
-			$path = self::get_file_path($src[0] . static::extension());
+			$path = self::get_file_path($fileInfos['path'] . static::extension());
 			if (!$path) {
 				continue;
 			}
@@ -155,14 +156,14 @@ class Service
 	 * If the file does not exist on the file system, the
 	 * function will return false.
 	 *
-	 * @param $path
+	 * @param $path - Path of file inside uploads folder
 	 * @return string
 	 * @since 0.1.0
 	 * @date 24/11/2021
 	 */
 	private static function get_file_path($path)
 	{
-		$file = wp_get_upload_dir()['path'] . DIRECTORY_SEPARATOR . basename($path);
+		$file = wp_get_upload_dir()['basedir'] . DIRECTORY_SEPARATOR . $path;
 		if (file_exists($file)) {
 			return $file;
 		}

--- a/core/Package/Service.php
+++ b/core/Package/Service.php
@@ -67,7 +67,7 @@ class Service
 
 		// Check if the attachment has already been compressed.
 		$id = attachment_url_to_postid($attachment['file']);
-		if (self::has_compressed($id)) {
+		if (self::has_compressed($id) && !$args['force']) {
 			return;
 		}
 


### PR DESCRIPTION
- Add --force & --thumbnails-only cli commands
- Prevent error when wp_get_attachment_image_src return false
- Fix get_file_path : The path of the uploads folder retrieved in the get_file_path function include the uploads sub-folder of the current month, not the uploads sub-folder of the file